### PR TITLE
Repoint API docs link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <div class="sidebar">
-            <a href="https://api.wattcarbon.com/redoc/" target="_blank">Check out our API Docs!</a>
+            <a href="https://api.wattcarbon.com/" target="_blank">Check out our API Docs!</a>
             <h2>Overview</h2>
             <ul>
                 <li><a class='sidebar-a' href="#" data-doc="README.md" class="active">Introduction</a></li>


### PR DESCRIPTION
They're now on the root of the domain rather than /redoc