### PR TITLE
Update some broken links

### DIFF
--- a/data_onboarding/Developer Guide.md
+++ b/data_onboarding/Developer Guide.md
@@ -38,7 +38,7 @@ token = token_payload["access_token"]
 client.headers["Authorization"] = "Bearer " + token
 ```
 
-See the documentation for [POST /auth/token](https://docs.wattcarbon.com/docs/wattcarbon/8b3f8e57ec2e9-create-token) for more information.
+See the documentation for [POST /auth/token](https://api.wattcarbon.com/#tag/Tokens/operation/create_token_auth_token_post) for more information.
 
 ## 2. Create a device.
 
@@ -107,9 +107,9 @@ create_device_response.raise_for_status()
 
 <!-- theme: info -->
 
-> If you have a unique ID for the site that you use for your own tracking, you can pass it in the `customId` field. The API will enforce that the same custom ID is never used on multiple sites in your account. See [Custom IDs](CustomIds.md) for more information.
+> If you have a unique ID for the site that you use for your own tracking, you can pass it in the `customId` field. The API will enforce that the same custom ID is never used on multiple sites in your account.
 
-See [POST /devices](https://docs.wattcarbon.com/docs/wattcarbon/4339aebb3db1a-create-device) for more information about all the potential values. If you need to change the device's parameters later on, you can use the [PUT /devices/{id}](https://docs.wattcarbon.com/docs/wattcarbon/ed3d2ae52c643-update-device) endpoint.
+See [POST /devices](https://api.wattcarbon.com/#tag/Devices/operation/create_device_devices_post) for more information about all the potential values. If you need to change the device's parameters later on, you can use the [PUT /devices/{id}](https://api.wattcarbon.com/#tag/Devices/operation/update_device_devices__device_id__put) endpoint.
 
 ## 3. Upload device data
 
@@ -126,6 +126,6 @@ datetime,value_kwh
 2022-08-01T04:00:00+00:00,1.6
 ```
 
-See [POST /devices/{device_id}/timeseries](https://docs.wattcarbon.com/docs/wattcarbon/dd24db62819b9-upload-device-timeseries) for more information about the file format and how to upload savings data.
+See [POST /devices/{device_id}/timeseries](https://api.wattcarbon.com/#tag/Devices/operation/upload_device_timeseries_devices__device_id__timeseries_post) for more information about the file format and how to upload savings data.
 
 For now, that is all you need to do to add a device and provide device data. We will include additional steps in the future to further automate our registration process, but for now please email <support@wattcarbon.com> when you have completed this process.

--- a/data_onboarding/Onboarding Guide.md
+++ b/data_onboarding/Onboarding Guide.md
@@ -33,11 +33,11 @@ The six broad device categories are:
 5. Energy Efficiency
 6. EV Charging
 
-The fields required at the device level will vary based on type of device. The [CreateDevice](https://docs.wattcarbon.com/docs/wattcarbon/4339aebb3db1a-create-device) endpoint can be used to create individual devices, and this page allows you to toggle to the device kind to see changing required fields based on device kind.
+The fields required at the device level will vary based on type of device. The [CreateDevice](https://api.wattcarbon.com/#tag/Devices/operation/create_device_devices_post) endpoint can be used to create individual devices, and this page allows you to toggle to the device kind to see changing required fields based on device kind.
 
-If you prefer, you can also use the bulk [CreateDevices](https://docs.wattcarbon.com/docs/wattcarbon/bc619ccedbe2d-create-devices) endpoint to upload an array of devices that are of the same kind via a CSV file. For details on this approach please contact us.
+If you prefer, you can also use the bulk [CreateDevices](https://api.wattcarbon.com/#tag/Devices/operation/create_devices_devices_csv_post) endpoint to upload an array of devices that are of the same kind via a CSV file. For details on this approach please contact us.
 
-Optional: Upload time-series data. The methodology will determine the specific [requirements](https://docs.wattcarbon.com/docs/wattcarbon/dd24db62819b9-upload-device-timeseries) for a csv. 
+Optional: Upload time-series data. The methodology will determine the specific [requirements](https://api.wattcarbon.com/#tag/Devices/operation/upload_device_timeseries_devices__device_id__timeseries_post) for a csv. 
 
 ## Step Two - Create Hourly Savings
 

--- a/m_and_v/plans/Elephant Energy.md
+++ b/m_and_v/plans/Elephant Energy.md
@@ -27,10 +27,10 @@ We expect to receive 12 pre-intervention bills representing approximately 12 mon
 
 ### User-Provided Data Requirements
 
-The following is a static description of the required and optional fields for a given Asset. An updated CSV template with the correct column names [is available here](https://api.wattcarbon.com/devices/csv/template/electrification_nrel_resstock_deemed) and timeseries description [is available here](https://docs.wattcarbon.com/docs/wattcarbon/qgeogozj1wujc-upload-device-timeseries).
+The following is a static description of the required and optional fields for a given Asset. An updated CSV template with the correct column names [is available here](https://api.wattcarbon.com/devices/csv/template/electrification_nrel_resstock_deemed) and timeseries description [is available here](https://api.wattcarbon.com/#tag/Devices/operation/upload_device_timeseries_devices__device_id__timeseries_post).
 
 ### Attributional Data
-The following data is required in addition to what is listed in the [Shared M&V Documentation](../Shared.md).
+The following data is required in addition to what is listed in the [Shared M&V Documentation](/#m_and_v%2FShared.md).
 
 #### General Building Characteristics
 


### PR DESCRIPTION
This updates some links that were using stoplight-style URLs.

However, it looks like links that are internal to the jekyll site aren't working even on the existing homepage. I think that means that the updates here that aren't to other domains (like api docs) will still be broken. I'm not quite sure what's going on there. It looks like despite being a static site we're doing it all with client-side routing?